### PR TITLE
Update circe

### DIFF
--- a/patchless-circe/src/test/scala/patchless/circe/extras/ConfigurablePatchJsonSpec.scala
+++ b/patchless-circe/src/test/scala/patchless/circe/extras/ConfigurablePatchJsonSpec.scala
@@ -10,8 +10,10 @@ import shapeless.record.Record
 
 class ConfigurablePatchJsonSpec extends FreeSpec with Matchers {
 
+
   "Configurable decoder" - {
     "Normal" in {
+      import io.circe.generic.extras.defaults._
       case class Foo(aString: String, bInt: Int, cBoolean: Boolean)
 
       def parsePatch(str: String) =
@@ -43,6 +45,7 @@ class ConfigurablePatchJsonSpec extends FreeSpec with Matchers {
     }
 
     "Options" in {
+      import io.circe.generic.extras.defaults._
       case class Foo(aString: Option[String])
       def parsePatch(str: String) =
         parse(str).valueOr(throw _).as[Patch[Foo]].valueOr(throw _)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 logLevel := Level.Warn
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.5")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "1.0.4-SNAPSHOT"


### PR DESCRIPTION
and work out the issues due to the changes in the behavior of extra's configuration. This now should be releasable with `sbt cross with-defaults` (or similar) assuming you have your sonatype creds setup the way `sbt-sonatype` and `sbt-pgp` expect. 